### PR TITLE
Modified 000-default to not touch cgi

### DIFF
--- a/overlay/etc/apache2/sites-available/000-default.conf
+++ b/overlay/etc/apache2/sites-available/000-default.conf
@@ -11,8 +11,6 @@ ServerName localhost
         DocumentRoot /var/www/
 </VirtualHost>
 
-ScriptAlias /cgi-bin/ /var/www/cgi-bin/
-
 <Directory /var/www/>
         Options Indexes FollowSymLinks MultiViews
 Require all granted


### PR DESCRIPTION
enables cgi by default on lamp and changes 000-default to not include cgi config

second part of closing https://github.com/turnkeylinux/tracker/issues/722
requires https://github.com/turnkeylinux/common/pull/79