### PR TITLE
Fixes Lamp on Safari Browsers not loading

### DIFF
--- a/conf.d/main
+++ b/conf.d/main
@@ -7,6 +7,10 @@ service mysql stop
 # enable cgi
 a2enmod cgi
 
+# enable header
+a2enmod headers
+a2enconf remove-upgrade-header
+
 # remove unrequired webcp icons (all except those named) 
 cd /var/www/images
 find . -type f ! -name "adminer.png" ! -name "shell.png" ! -name "tab.png" ! -name "webmin.png" -delete

--- a/overlay/etc/apache2/conf-available/remove-upgrade-header.conf
+++ b/overlay/etc/apache2/conf-available/remove-upgrade-header.conf
@@ -1,0 +1,3 @@
+<IfModule mod_headers.c>
+    Header always unset Upgrade
+</IfModule>

--- a/overlay/etc/apache2/sites-available/000-default.conf
+++ b/overlay/etc/apache2/sites-available/000-default.conf
@@ -3,6 +3,9 @@ ServerName localhost
 <VirtualHost *:80>
     ServerAdmin webmaster@localhost
     DocumentRoot /var/www/
+    <IfModule mod_headers.c>
+        Header always unset Upgrade
+    </IfModule>
 </VirtualHost>
 
 <VirtualHost *:443>


### PR DESCRIPTION
So basically in the last month (since MAY😯) LAMP from TKL stoped working in Safari broswers. It tooked me a long time to discover why. Basically Safari doesn't provide a full documentation why the behaviour was happening. The logs from apache weren't sufficient to diganose. 

The problems when googled were bizarrly explained by apple as Update of Safari, but the problem is that since latest bump iOS and macOS update to the Safari Kernel it can not set header properly

https://support.apple.com/en-in/102456
SOF is almost dead and would help It wasn't cors or anything like it:
https://stackoverflow.com/questions/79390056/safari-not-redirecting-using-window-location-replace-or-window-location-href-on

And the Ubuntu forums also missed it:
https://askubuntu.com/questions/1529413/the-default-apache-web-server-page-says-to-replace-a-file-before-continuing-use

As I dont have a mac and have to emulate it trought QEMU it was a painly hard problem to solve, BUT!

reddit gave me a solution:
www.reddit.com/r/applehelp/comments/1fjx07n/only_on_apple_devices_safari_cant_open_page/

Thanks to Leonardo Chagas for the forwarding message

The hot patch came in second and suddenly everything is back and working

So please consider just following the reddit recomendations

If any of the maintainers think we must do something different please fell free to contribute to the PR

Best regard to all